### PR TITLE
Remove DeviceControl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ rust-version = "1.65.0"
 [dependencies.libc]
 version = "0.2"
 default-features = false
-# For exclusion of multiple devices on the same queue.
-[dependencies.spin]
-version = "0.9"
-features = ["rwlock"]
-default-features = false
 
 [dev-dependencies.clap]
 version = "4"

--- a/src/xsk.rs
+++ b/src/xsk.rs
@@ -110,7 +110,6 @@ pub struct Umem {
     umem_area: NonNull<[u8]>,
     config: UmemConfig,
     fd: Arc<SocketFd>,
-    devices: DeviceControl,
 }
 
 /// A raw pointer to a specific chunk in a Umem.
@@ -125,20 +124,6 @@ pub struct UmemChunk {
     ///
     /// This is the basis of the address calculation shared with the kernel.
     pub offset: u64,
-}
-
-#[derive(Clone)]
-struct DeviceControl {
-    /// The tracker, not critical for memory safety (here anyways) but correctness.
-    inner: Arc<dyn ControlSet>,
-}
-
-/// A synchronized set for tracking which `IfCtx` are taken.
-trait ControlSet: Send + Sync + 'static {
-    fn insert(&self, _: IfCtx) -> bool;
-    #[allow(unused)] // We do not provide a check operation yet.
-    fn contains(&self, _: &IfCtx) -> bool;
-    fn remove(&self, _: &IfCtx);
 }
 
 /// One prepared socket for a receive/transmit pair.
@@ -159,8 +144,6 @@ pub struct DeviceQueue {
     fcq: DeviceRings,
     /// This is also a socket.
     socket: Socket,
-    /// Reference to de-register.
-    devices: DeviceControl,
 }
 
 /// An owner of receive/transmit queues.

--- a/src/xsk/user.rs
+++ b/src/xsk/user.rs
@@ -69,12 +69,6 @@ impl DeviceQueue {
     }
 }
 
-impl Drop for DeviceQueue {
-    fn drop(&mut self) {
-        self.devices.remove(&self.socket.info.ctx);
-    }
-}
-
 impl RingRx {
     /// Receive some buffers.
     ///


### PR DESCRIPTION
The `ControlSet` trait was used to make sure multiple `DeviceQueue` could not be created with the same `IfCtx`.
This had one flaw: If running multiple processes, the check would not raise an Error, instead the error is raised afterwards during `Umem.bind()` (giving `16: Device or resource busy`) where the OS itself does the check.

This means even after removing the ControlSet completely, it's still prevented to create multiple sockets using the same `IfCtx`. More importantly, it's more predictable *where* and *which* error is raised because no matter if running in a single process or multiple, the error will always be on the same call with the same errno. Before, it could be err 22 when calling `fq_cq()` OR err 16 when calling `bind()` when it was actually the exact same problem.

Why is this change necessary?
https://github.com/197g/xdpilone/issues/19 wants to add support for splitting the `DeviceQueue` object into separate fill/complettion ring objects. Since the destructor of `DeviceQueue` used to remove the entry from `ControlSet`, each separate ring would need its own reference to it which would require more complex handling of the lifetime.

As far as I can tell, `ControlSet` is never exposed publicly, so this change should not break any code depending on xdpilone. (Except for the maybe being raised during a later step - which could also happen before this change anyways so code should expect it)

Please let me know if you have any concerns regarding this change. As far as I can tell, it only makes the library more predictable and lays the groundwork for #19.